### PR TITLE
Fix Game ID off-by-one in predictions_history

### DIFF
--- a/scripts/weekly_data_process/weekly_data_process.R
+++ b/scripts/weekly_data_process/weekly_data_process.R
@@ -124,7 +124,8 @@ if (new_data) {
   dat$game_dat <- dat$game_dat[!dup_games,]
   
   dat$game_dat <- dat$game_dat %>%
-    mutate(Game = row_number()) %>%
+    mutate(Game = if_else(!is.na(Game), Game,
+                          max(Game, na.rm = TRUE) + cumsum(is.na(Game)))) %>%
     ungroup() %>%
     mutate(Venue = stringr::str_trim(Venue) %>% venue_fix()) %>%
     mutate(Round = Round.Number) 
@@ -381,7 +382,12 @@ if (new_data) {
           existing <- existing %>%
             mutate(Time         = as.character(Time),
                    Predicted_At = as.character(Predicted_At)) %>%
-            filter(Predicted_Round != unique(new_preds$Predicted_Round))
+            filter(Predicted_Round != unique(new_preds$Predicted_Round)) %>%
+            select(-Game) %>%
+            left_join(
+              dat$game_dat %>% select(Game, Season, Round.Number, Home.Team, Away.Team),
+              by = c("Season", "Round.Number", "Home.Team", "Away.Team")
+            )
           bind_rows(existing, new_preds) %>% write_csv(pred_history_path)
         }
       } else {


### PR DESCRIPTION
## Summary

- Replaces `row_number()` Game ID assignment with logic that preserves stable AFLTables Game IDs for completed results, only extending sequentially for fixture games (which arrive with `Game = NA` from the AFL API)
- On each pipeline run, refreshes Game IDs in existing `predictions_history` entries by re-joining to current `game_dat` on `Season + Round.Number + Home.Team + Away.Team` — self-healing any IDs saved incorrectly in a prior run

## Root cause

When a game (e.g. Hawthorn vs Sydney, Round 2) is played during the Round 1 week, it moves to `status="CONCLUDED"` in the AFL API fixture and gets filtered out at line 120, but hasn't yet been indexed by AFLTables. It's temporarily absent from `game_dat`, causing all subsequent games to receive row numbers one too low. Those wrong IDs get written to `predictions_history`, then when AFLTables catches up the results file has the correct IDs — causing a join mismatch in the downstream Quarto site.

## Test plan

- [ ] Run `weekly_data_process.R` after Round 1/2 results are available
- [ ] Confirm `AFLM_predictions_history_2026.csv` has Game 16853 = Hawthorn vs Sydney and Game 16854 = Adelaide vs Footscray
- [ ] Confirm `AFLM_results.csv` has the same Game IDs for the same matchups
- [ ] Verify `join(predictions_history, results, by = "Game")` produces correct team matches for all Round 2, 2026 games

🤖 Generated with [Claude Code](https://claude.com/claude-code)