### PR TITLE
Fix Squiggle round field + testthat 3.x CI failure

### DIFF
--- a/tests/run_tests.R
+++ b/tests/run_tests.R
@@ -1,8 +1,4 @@
 library(testthat)
 library(here)
 
-results <- test_dir(here::here("tests", "testthat"), reporter = "progress")
-
-if (!all_passed(results)) {
-  quit(status = 1)
-}
+test_dir(here::here("tests", "testthat"), reporter = "progress", stop_on_failure = TRUE)


### PR DESCRIPTION
## Summary

- **Add `round` field to `predictions_new.csv`** — Squiggle was rejecting tips from R13 onwards because the AFL shifted dates around and without a `round` field the bot couldn't match predictions to games
- **Fix `tests/run_tests.R` CI failure** — `all_passed()` was removed in testthat 3.0.0; all 29 tests were passing but the job crashed immediately after on the missing function. Replaced with the modern `stop_on_failure = TRUE` parameter on `test_dir()`

## Test plan

- [ ] Confirm Squiggle accepts tips with the new `round` field
- [ ] Confirm the GitHub Actions `update-data` job passes (previously failing with `could not find function "all_passed"` despite all tests passing)
- [ ] Verify no regressions in the 29 existing data-integrity tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)